### PR TITLE
게시물 조회수 기능 #18

### DIFF
--- a/src/main/java/com/team2/controller/PostController.java
+++ b/src/main/java/com/team2/controller/PostController.java
@@ -53,9 +53,13 @@ public class PostController {
             return;
         }
 
+        post.increaseCount();
+
         System.out.printf("번호: %d\n", post.getId());
         System.out.printf("제목: %s\n", post.getTitle());
         System.out.printf("내용: %s\n", post.getContent());
+        System.out.printf("조회수: %d\n", post.getCount());
+        System.out.println("----------------------------");
         System.out.printf("작성일: %s\n", post.getCreatedAt().format(post.getFormatter()));
         System.out.printf("수정일: %s\n", post.getModifiedAt().format(post.getFormatter()));
     }

--- a/src/main/java/com/team2/domain/post/Post.java
+++ b/src/main/java/com/team2/domain/post/Post.java
@@ -18,14 +18,20 @@ public class Post {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private final DateTimeFormatter formatter;
+    private int count; // 조회수
 
     public Post(String title, String content) {
         this.title = title;
         this.content = content;
         this.formatter = AppContext.formatter;
+        this.count = 0;
     }
 
     public boolean isNew() {
         return id == 0;
+    }
+
+    public void increaseCount() {
+        this.count++;
     }
 }


### PR DESCRIPTION
---

## 🎯 목적

게시물에 조회수 필드 추가 후 게시글 상세보기 기능 사용 시 조회수가 오르도록 구현

## ✅ 완료할 일

- [x] Post entity의 조회수 필드 `count` 생성
- [x] 게시글 상세보기 시 조회수 증가 로직 구현

## 💬 추가 의논 사항

```java
public class Post {
    // ...
    private int count; // 조회수
    
    public Post(String title, String content) {
        // ...
        this.count = 0; // Post 생성 시 0으로 초기화
    }

    public void increaseCount() {
        this.count++;
    }
```

Post 클래스에 위와 같이 조회수 필드 `count`를 생성하고 초기화 세팅과 증가 메소드를 만들었습니다.

```java
    public void actionDetail(Rq rq) {
        // ...
        Post post = postService.findPostById(id);
        // ...
        post.increaseCount();
        // ...
        System.out.printf("조회수: %d\n", post.getCount());
```

게시글 상세보기 기능이 실행될 때 increaseCount() 메소드를 실행하게 하고
이후 출력 내용에서 조회수 항목을 추가했습니다.
