### PR TITLE
게시글 정렬 옵션(기본, id, 생성일, 수정일) #21

### DIFF
--- a/src/main/java/com/team2/controller/PostController.java
+++ b/src/main/java/com/team2/controller/PostController.java
@@ -30,8 +30,11 @@ public class PostController {
     public void actionList(Rq rq) {
         String keywordType = rq.getParam("keywordType", "");
         String keyword = rq.getParam("keyword", "");
+        String sortBy = rq.getParam("sortBy", "");
 
-        List<Post> posts = postService.findForList(keywordType, keyword);
+        List<Post> posts = postService.findForList(keywordType, keyword, sortBy);
+
+        if (posts == null) return;
 
         System.out.println("번호 / 제목 / 내용 / 작성일 / 수정일");
         System.out.println("----------------------------");

--- a/src/main/java/com/team2/repository/PostRepository.java
+++ b/src/main/java/com/team2/repository/PostRepository.java
@@ -34,7 +34,7 @@ public class PostRepository {
         return post;
     }
 
-    public List<Post> findForList(String keywordType, String keyword) {
+    public List<Post> findForList(String keywordType, String keyword, String sortBy) {
         List<Post> posts = new ArrayList<>(this.postList);
 
         switch (keywordType) {
@@ -43,9 +43,24 @@ public class PostRepository {
             case "" -> posts.removeIf(post ->
                     !post.getTitle().contains(keyword) &&
                     !post.getContent().contains(keyword));
+            default -> {
+                System.out.println("잘못된 검색 유형입니다.");
+                return null;
+            }
         }
 
-        return posts.reversed();
+        switch(sortBy) {
+            case "id" -> posts.sort((p1, p2) -> Integer.compare(p1.getId(), p2.getId())); // ID 오름차순
+            case "createdAt" -> posts.sort((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())); // 작성일 오름차순
+            case "modifiedAt" -> posts.sort((p1, p2) -> p1.getModifiedAt().compareTo(p2.getModifiedAt())); // 수정일 오름차순
+            case "" -> posts.sort((p1, p2) -> Integer.compare(p2.getId(), p1.getId())); // 기본값: ID 내림차순
+            default -> {
+                System.out.println("잘못된 정렬 기준입니다.");
+                return null;
+            }
+        }
+
+        return posts;
     }
 
     public void delete(Post post) {

--- a/src/main/java/com/team2/service/PostService.java
+++ b/src/main/java/com/team2/service/PostService.java
@@ -18,8 +18,8 @@ public class PostService {
         return post;
     }
 
-    public List<Post> findForList(String keywordType, String keyword) {
-        return postRepository.findForList(keywordType, keyword);
+    public List<Post> findForList(String keywordType, String keyword, String sortBy) {
+        return postRepository.findForList(keywordType, keyword, sortBy);
     }
 
     public Post findPostById(int id) {


### PR DESCRIPTION
---

## 🎯 목적

게시글 목록 기능에서 `sortBy` param을 통해 id, 생성일, 수정일에 따라 정렬하여 출력하는 기능 구현

## ✅ 완료할 일

- [x] 목록 기능 명령어 `sortBy` param 추가
- [x] `sortBy` param에 따른 게시글 목록 정렬 기능 구현

## 💬 추가 의논 사항

```java
String sortBy = rq.getParam("sortBy", "");
```

`PostController`의 `actionList` 메소드에서 위와 같이 `sortBy` param을 추가하였습니다.

```java
        switch(sortBy) {
            case "id" -> posts.sort((p1, p2) -> Integer.compare(p1.getId(), p2.getId())); // ID 오름차순
            case "createdAt" -> posts.sort((p1, p2) -> p1.getCreatedAt().compareTo(p2.getCreatedAt())); // 작성일 오름차순
            case "modifiedAt" -> posts.sort((p1, p2) -> p1.getModifiedAt().compareTo(p2.getModifiedAt())); // 수정일 오름차순
            case "" -> posts.sort((p1, p2) -> Integer.compare(p2.getId(), p1.getId())); // 기본값: ID 내림차순
            default -> {
                System.out.println("잘못된 정렬 기준입니다.");
                return null;
            }
        }

        return posts;
```

이후 `PostRepository`의 `findForList` 메소드에서 해당 param의 값을 바탕으로
위와 같이 id, 생성일, 수정일에 따라 return 시킬 게시글 리스트인 `posts`를 정렬하였습니다.

해당 명령어는 `목록?sortBy=(정렬 방식)`의 형태로 사용할 수 있습니다.
`sortBy` param 생략시 기존의 id 내림차순 정렬로 목록이 불려옵니다.
또한, 이전에 구현한 검색 기능과 혼용하여 쓸 수 있습니다. ex) `목록?sortBy=id&keywordType=title&keyword=제목`

### 잘못 된 param 값 입력 시 처리

추가적으로 정해진 param에 잘못된 값을 입력할 시 ex) `목록?sortBy=sdsdsd`
게시글 리스트인 `posts` 대신 null값을 반환하게 만들었습니다.

```java
        List<Post> posts = postService.findForList(keywordType, keyword, sortBy);

        if (posts == null) return;
```

PostController의 actionList 메서드에서는 잘못된 정렬 기준으로 인해 null이 반환되면, 
목록 출력 없이 명령어 입력 상태로 바로 돌아가도록 처리했습니다.